### PR TITLE
Fixed

### DIFF
--- a/src/java/com/tsp/gespro/Services/Allservices.java
+++ b/src/java/com/tsp/gespro/Services/Allservices.java
@@ -304,28 +304,7 @@ public class Allservices {
 
         return lista; 
     }
-    
-    public List queryClientesMatrizDAO(){  
-        
-            List<Cliente> lista = new ArrayList<>();  
-            Session session = null;
-
-        try 
-        { 
-            String idClientes= new ClientesClientesDAO().ClientesIdMatriz();
-            session = HibernateUtil.getSessionFactory().openSession(); 
-            Transaction tx = session.beginTransaction(); 
-            String query = "from Cliente WHERE id_cliente IN  ("+idClientes+")";
-            lista = session.createQuery(query).list();
-        }
-        finally 
-        { 
-            session.close(); 
-        }  
-
-        return lista; 
-    }
-        
+      
     public List getActividadesFull(List<Actividad> listaActividades){  
         // Lista de objeto con los objectos de actividades, punto y proyeco
         // Por actividad.

--- a/src/java/com/tsp/gespro/hibernate/dao/ClienteDAO.java
+++ b/src/java/com/tsp/gespro/hibernate/dao/ClienteDAO.java
@@ -116,6 +116,35 @@ public class ClienteDAO {
     { 
         return lista(); 
     }    
+    
+    public List clientesMatrices() throws HibernateException 
+    { 
+        List<Cliente> lista = null;  
+        ClientesClientesDAO relacion=new ClientesClientesDAO();
+        String idMatrices=relacion.clientesIdMatriz();
+        
+        try 
+        { 
+            iniciaOperacion(); 
+            if(!idMatrices.equals("")){
+                String where="where id_cliente in ";
+                where+="("+idMatrices+")";
+                lista = sesion.createQuery("from Cliente "+where).list(); 
+            }
+            
+        }
+        finally 
+        { 
+            sesion.close(); 
+        }  
+
+        return lista; 
+    }
+  
+    public List getClientesMatrices()
+    { 
+        return clientesMatrices(); 
+    }    
      
     private void iniciaOperacion() throws HibernateException 
     { 

--- a/src/java/com/tsp/gespro/hibernate/dao/ClientesClientesDAO.java
+++ b/src/java/com/tsp/gespro/hibernate/dao/ClientesClientesDAO.java
@@ -3,13 +3,8 @@
  * and open the template in the editor.
  */
 package com.tsp.gespro.hibernate.dao;
-
-import com.tsp.gespro.Services.Allservices;
-import com.tsp.gespro.hibernate.pojo.Cliente;
 import com.tsp.gespro.hibernate.pojo.ClientesClientes;
 import com.tsp.gespro.hibernate.pojo.HibernateUtil;
-import java.util.AbstractList;
-import java.util.ArrayList;
 import java.util.List;
 import org.hibernate.HibernateException;
 import org.hibernate.Session;
@@ -124,7 +119,7 @@ public class ClientesClientesDAO {
      * Verifica si ya existe un registro similar, de ser así, regresa el id
      * de lo contrario, regresa un 0.
      ***/
-    public int exist(String where) throws HibernateException 
+    public List exist(String where) throws HibernateException 
     { 
         List<ClientesClientes> lista = null; 
         int id=0;
@@ -133,21 +128,16 @@ public class ClientesClientesDAO {
         { 
             iniciaOperacion(); 
             lista = sesion.createQuery("from ClientesClientes "+where).list();
-            if(lista!=null){
-                if(lista.size()>0){
-                    return lista.get(0).getId();
-                }
-            }
         }
         finally 
         { 
             sesion.close(); 
         }  
 
-        return id; 
+        return lista; 
     }
    
-    public String ClientesIdMatriz() throws HibernateException 
+    public String clientesIdMatriz() throws HibernateException 
     { 
         List<ClientesClientes> lista = null; 
         String idClientes="";
@@ -156,12 +146,13 @@ public class ClientesClientesDAO {
         { 
             iniciaOperacion(); 
             lista = sesion.createQuery("from ClientesClientes where cliente_id=cliente_sucursal_id ").list();
-            if(lista!=null){
+            if(lista!=null && lista.size()>0){
               for(ClientesClientes obj: lista){
                   idClientes+=obj.getClienteId()+",";
-              }  
+              }
+              idClientes+=idClientes.substring(0,idClientes.length()-1);
             }
-            idClientes+=idClientes.substring(0,idClientes.length()-1);
+            
         }
         finally 
         { 
@@ -169,6 +160,41 @@ public class ClientesClientesDAO {
         }  
 
         return idClientes; 
+    }
+    
+    
+    public void crearRelacionClientes(int idCliente,int idClienteSucursal, int tipo){
+        
+        // Eliminamos todos los registros existentes con estos clientes.
+        String where="where cliente_id="+idCliente+" AND cliente_sucursal_id="+idCliente;
+        where+="OR cliente_id="+idCliente;
+        List<ClientesClientes> relacionesExistentes= exist(where);
+        for(ClientesClientes relacion:relacionesExistentes){
+            System.out.print("Borrando " + relacion.getId());
+            eliminar(relacion.getId());
+        }
+        
+        System.out.print("Params");
+        System.out.print(idCliente);
+        System.out.print(idClienteSucursal);
+        System.out.print(tipo);
+        // Si es 1 quiere decir, que es matriz
+       if(tipo==1){
+            System.out.print("Entra a uno");
+            ClientesClientes relacionClientes=new ClientesClientes();
+            relacionClientes.setClienteId(idCliente);
+            relacionClientes.setClienteSucursalId(idCliente);
+            guardar(relacionClientes);
+       }
+       
+       // Si es 0 quiere decir que no es matriz y tienen su sucursal matriz.
+       if(tipo==0){
+           System.out.print("Entra a 0");
+            ClientesClientes relacionClientes=new ClientesClientes();
+            relacionClientes.setClienteId(idCliente);
+            relacionClientes.setClienteSucursalId(idClienteSucursal);
+            guardar(relacionClientes);
+        }
     }
      
     private void iniciaOperacion() throws HibernateException 

--- a/src/java/com/tsp/gespro/hibernate/dao/ClientesClientesDAO.java
+++ b/src/java/com/tsp/gespro/hibernate/dao/ClientesClientesDAO.java
@@ -164,23 +164,17 @@ public class ClientesClientesDAO {
     
     
     public void crearRelacionClientes(int idCliente,int idClienteSucursal, int tipo){
-        
+
         // Eliminamos todos los registros existentes con estos clientes.
         String where="where cliente_id="+idCliente+" AND cliente_sucursal_id="+idCliente;
         where+="OR cliente_id="+idCliente;
         List<ClientesClientes> relacionesExistentes= exist(where);
         for(ClientesClientes relacion:relacionesExistentes){
-            System.out.print("Borrando " + relacion.getId());
             eliminar(relacion.getId());
         }
-        
-        System.out.print("Params");
-        System.out.print(idCliente);
-        System.out.print(idClienteSucursal);
-        System.out.print(tipo);
+
         // Si es 1 quiere decir, que es matriz
        if(tipo==1){
-            System.out.print("Entra a uno");
             ClientesClientes relacionClientes=new ClientesClientes();
             relacionClientes.setClienteId(idCliente);
             relacionClientes.setClienteSucursalId(idCliente);
@@ -189,7 +183,6 @@ public class ClientesClientesDAO {
        
        // Si es 0 quiere decir que no es matriz y tienen su sucursal matriz.
        if(tipo==0){
-           System.out.print("Entra a 0");
             ClientesClientes relacionClientes=new ClientesClientes();
             relacionClientes.setClienteId(idCliente);
             relacionClientes.setClienteSucursalId(idClienteSucursal);

--- a/web/jsp/catClientes/ajaxAdicionalesCliente.jsp
+++ b/web/jsp/catClientes/ajaxAdicionalesCliente.jsp
@@ -4,13 +4,13 @@
 <%@page contentType="text/html" pageEncoding="UTF-8"%>
 <jsp:useBean id="user" scope="session" class="com.tsp.gespro.bo.UsuarioBO"/>
 <%
-    CampoAdicionalClienteValorDAO cacvdao=new CampoAdicionalClienteValorDAO();    
+    CampoAdicionalClienteValorDAO cacvdao=new CampoAdicionalClienteValorDAO(); 
+    
     try{
        cacvdao.guardarCambios(request.getParameterMap());
        out.print("<--EXITO-->" + "Se guardó correctamente. ");
     }catch(Exception ex){
         ex.printStackTrace();
-         out.print("<--hola-->" + ex.getMessage());
         out.print("<--ERROR-->" + ex.getMessage());
     }
            

--- a/web/jsp/catClientes/catClientes_ajax.jsp
+++ b/web/jsp/catClientes/catClientes_ajax.jsp
@@ -71,13 +71,12 @@
     String nombreComercial="";
     
     int idSucursalEmpresaAsignado = idEmpresa;
-    int tipo=1;
-    
-    
-    if(request.getParameter("tipo")!=null){
+    int tipo=2;
+    if(request.getParameter("matriz")!=null){
         tipo = Integer.parseInt(request.getParameter("tipo"));
     }
-    
+    out.print("Matriz");
+    out.print(tipo);
     /*
     * Recepción de valores
     */
@@ -226,39 +225,17 @@
                      */
                     if(idCliente>0){
                         
+                        // Guardar relación clientes con sus sucursal matriz.
+                        ClientesClientesDAO obj=new ClientesClientesDAO();
+                        
+                        // tipo 1 significa que es matriz.
                         if(tipo==1){
-                          String where="where cliente_id="+idCliente+" AND cliente_sucursal_id="+idCliente;
-                          int relacion=new ClientesClientesDAO().exist(where);
-                          if(relacion==0){
-                              ClientesClientes relacionClientes=new ClientesClientes();
-                              relacionClientes.setClienteId(idCliente);
-                              relacionClientes.setClienteSucursalId(idCliente);
-                              ClientesClientesDAO obj=new ClientesClientesDAO();
-                              obj.guardar(relacionClientes);
-                          }else{
-                              ClientesClientesDAO obj=new ClientesClientesDAO();
-                              ClientesClientes relacionClientes=obj.getById(relacion);;
-                              relacionClientes.setClienteId(idCliente);
-                              relacionClientes.setClienteSucursalId(idCliente);
-                              obj.actualizar(relacionClientes);
-                          }
-                        }else{
+                         obj.crearRelacionClientes(idCliente, idCliente,1);
+                        }
+                        // tipo 0 significa que es sucursal.
+                        if(tipo==0){
                           int idC= Integer.parseInt(request.getParameter("idC"));
-                          String where="where cliente_id="+idCliente+" AND cliente_sucursal_id="+idC;
-                          int relacion=new ClientesClientesDAO().exist(where);
-                          if(relacion==0){
-                              ClientesClientes relacionClientes=new ClientesClientes();
-                              relacionClientes.setClienteId(idCliente);
-                              relacionClientes.setClienteSucursalId(idC);
-                              ClientesClientesDAO obj=new ClientesClientesDAO();
-                              obj.guardar(relacionClientes);
-                          }else{
-                              ClientesClientesDAO obj=new ClientesClientesDAO();
-                              ClientesClientes relacionClientes=obj.getById(relacion);;
-                              relacionClientes.setClienteId(idCliente);
-                              relacionClientes.setClienteSucursalId(idC);
-                              obj.actualizar(relacionClientes);
-                          }
+                          obj.crearRelacionClientes(idCliente,idC,1);
                         }
                         
                         //edita express
@@ -346,8 +323,8 @@
                             campoContenidoDaoImpl.insert(cliPersonalizados);
                         }*/
                         /////**--
-                        
-                        try{
+
+                            try{
                             new ClienteDaoImpl(user.getConn()).update(clienteDto.createPk(), clienteDto);
 
                             out.print("<!--EXITO-->Registro actualizado satisfactoriamente");
@@ -488,7 +465,18 @@
             clienteDto.setMunicipio(municipio);
             clienteDto.setEstado(estado);
             clienteDto.setPais(pais);
-            //clienteDto.setSincronizacionMicrosip(2);
+            // Guardar relación clientes con sus sucursal matriz.
+            ClientesClientesDAO obj=new ClientesClientesDAO();
+
+            // tipo 1 significa que es matriz.
+            if(tipo==1){
+             obj.crearRelacionClientes(clienteDto.getIdCliente(),clienteDto.getIdCliente(),1);
+            }
+            // tipo 0 significa que es sucursal.
+            if(tipo==0){
+              int idC= Integer.parseInt(request.getParameter("idC"));
+              obj.crearRelacionClientes(clienteDto.getIdCliente(),idC,1);
+            }
 
             try{
                 new ClienteDaoImpl(user.getConn()).update(clienteDto.createPk(), clienteDto);
@@ -630,6 +618,19 @@
                     Cliente clienteDto = clienteBO.getCliente();
 
                     clienteDto.setIdEstatus(estatus);
+                    
+                    // Guardar relación clientes con sus sucursal matriz.
+                    ClientesClientesDAO obj=new ClientesClientesDAO();
+                    
+                    // tipo 1 significa que es matriz.
+                    if(tipo==1){
+                     obj.crearRelacionClientes(idCliente,idCliente,1);
+                    }
+                    // tipo 0 significa que es sucursal.
+                    if(tipo==0){
+                      int idC= Integer.parseInt(request.getParameter("idC"));
+                      obj.crearRelacionClientes(idCliente,idC,1);
+                    }
                     /*if (matriz > 0) {
                         clienteDto.setMatriz(matriz);
                     } else {
@@ -814,42 +815,20 @@
                      * Realizamos el insert
                      */
                     ClientePk clientePk = clientesDaoImpl.insert(clienteDto);
-                    int clienteid=clientePk.getIdCliente();
-                    if(tipo==1){
+                    
+                    // Guardar relación clientes con sus sucursal matriz.
+                    ClientesClientesDAO obj=new ClientesClientesDAO();
 
-                      String where="where cliente_id="+clienteid+" AND cliente_sucursal_id="+clienteid;
-                      int relacion=new ClientesClientesDAO().exist(where);
-                      if(relacion==0){
-                          ClientesClientes relacionClientes=new ClientesClientes();
-                          relacionClientes.setClienteId(clienteid);
-                          relacionClientes.setClienteSucursalId(clienteid);
-                          ClientesClientesDAO obj=new ClientesClientesDAO();
-                          obj.guardar(relacionClientes);
-                      }else{
-                          ClientesClientesDAO obj=new ClientesClientesDAO();
-                          ClientesClientes relacionClientes=obj.getById(relacion);;
-                          relacionClientes.setClienteId(clienteid);
-                          relacionClientes.setClienteSucursalId(clienteid);
-                          obj.actualizar(relacionClientes);
-                      }
-                    }else{
-                      int idC= Integer.parseInt(request.getParameter("idC"));
-                      String where="where cliente_id="+clienteid+" AND cliente_sucursal_id="+idC;
-                      int relacion=new ClientesClientesDAO().exist(where);
-                      if(relacion==0){
-                          ClientesClientes relacionClientes=new ClientesClientes();
-                          relacionClientes.setClienteId(clienteid);
-                          relacionClientes.setClienteSucursalId(idC);
-                          ClientesClientesDAO obj=new ClientesClientesDAO();
-                          obj.guardar(relacionClientes);
-                      }else{
-                          ClientesClientesDAO obj=new ClientesClientesDAO();
-                          ClientesClientes relacionClientes=obj.getById(relacion);;
-                          relacionClientes.setClienteId(clienteid);
-                          relacionClientes.setClienteSucursalId(idC);
-                          obj.actualizar(relacionClientes);
-                      }
+                    // tipo 1 significa que es matriz.
+                    if(tipo==1){
+                     obj.crearRelacionClientes(clientePk.getIdCliente(), clientePk.getIdCliente(),1);
                     }
+                    // tipo 0 significa que es sucursal.
+                    if(tipo==0){
+                      int idC= Integer.parseInt(request.getParameter("idC"));
+                      obj.crearRelacionClientes(clientePk.getIdCliente(),idC,1);
+                    }
+                        
                         
                     
                     /////**--Insertamos los registros de datos personalizados:

--- a/web/jsp/catClientes/catClientes_ajax.jsp
+++ b/web/jsp/catClientes/catClientes_ajax.jsp
@@ -72,11 +72,9 @@
     
     int idSucursalEmpresaAsignado = idEmpresa;
     int tipo=2;
-    if(request.getParameter("matriz")!=null){
-        tipo = Integer.parseInt(request.getParameter("tipo"));
+    if(request.getParameter("tipoCliente")!=null){
+        tipo = Integer.parseInt(request.getParameter("tipoCliente"));
     }
-    out.print("Matriz");
-    out.print(tipo);
     /*
     * Recepción de valores
     */
@@ -230,12 +228,12 @@
                         
                         // tipo 1 significa que es matriz.
                         if(tipo==1){
-                         obj.crearRelacionClientes(idCliente, idCliente,1);
+                         obj.crearRelacionClientes(idCliente, idCliente,tipo);
                         }
                         // tipo 0 significa que es sucursal.
                         if(tipo==0){
                           int idC= Integer.parseInt(request.getParameter("idC"));
-                          obj.crearRelacionClientes(idCliente,idC,1);
+                          obj.crearRelacionClientes(idCliente,idC,tipo);
                         }
                         
                         //edita express
@@ -409,7 +407,18 @@
                             }
                         }*/
                         /////**--
-
+                         // Guardar relación clientes con sus sucursal matriz.
+                        ClientesClientesDAO obj=new ClientesClientesDAO();
+                        
+                        // tipo 1 significa que es matriz.
+                        if(tipo==1){
+                         obj.crearRelacionClientes(clienteDto.getIdCliente(),clienteDto.getIdCliente(),tipo);
+                        }
+                        // tipo 0 significa que es sucursal.
+                        if(tipo==0){
+                          int idC= Integer.parseInt(request.getParameter("idC"));
+                          obj.crearRelacionClientes(clienteDto.getIdCliente(),idC,tipo);
+                        }    
                         //Relacion con vendedor
                         if (idVendedor > 0){
                             RelacionClienteVendedor clienteVendedorDto = new RelacionClienteVendedor();
@@ -470,12 +479,12 @@
 
             // tipo 1 significa que es matriz.
             if(tipo==1){
-             obj.crearRelacionClientes(clienteDto.getIdCliente(),clienteDto.getIdCliente(),1);
+             obj.crearRelacionClientes(clienteDto.getIdCliente(),clienteDto.getIdCliente(),tipo);
             }
             // tipo 0 significa que es sucursal.
             if(tipo==0){
               int idC= Integer.parseInt(request.getParameter("idC"));
-              obj.crearRelacionClientes(clienteDto.getIdCliente(),idC,1);
+              obj.crearRelacionClientes(clienteDto.getIdCliente(),idC,tipo);
             }
 
             try{
@@ -624,12 +633,12 @@
                     
                     // tipo 1 significa que es matriz.
                     if(tipo==1){
-                     obj.crearRelacionClientes(idCliente,idCliente,1);
+                     obj.crearRelacionClientes(idCliente,idCliente,tipo);
                     }
                     // tipo 0 significa que es sucursal.
                     if(tipo==0){
                       int idC= Integer.parseInt(request.getParameter("idC"));
-                      obj.crearRelacionClientes(idCliente,idC,1);
+                      obj.crearRelacionClientes(idCliente,idC,tipo);
                     }
                     /*if (matriz > 0) {
                         clienteDto.setMatriz(matriz);
@@ -821,12 +830,12 @@
 
                     // tipo 1 significa que es matriz.
                     if(tipo==1){
-                     obj.crearRelacionClientes(clientePk.getIdCliente(), clientePk.getIdCliente(),1);
+                     obj.crearRelacionClientes(clientePk.getIdCliente(), clientePk.getIdCliente(),tipo);
                     }
                     // tipo 0 significa que es sucursal.
                     if(tipo==0){
                       int idC= Integer.parseInt(request.getParameter("idC"));
-                      obj.crearRelacionClientes(clientePk.getIdCliente(),idC,1);
+                      obj.crearRelacionClientes(clientePk.getIdCliente(),idC,tipo);
                     }
                         
                         

--- a/web/jsp/catClientes/catClientes_form.jsp
+++ b/web/jsp/catClientes/catClientes_form.jsp
@@ -354,11 +354,9 @@
                 ocultarTipoCliente();
                 if (tipoCliente == "1") {
                     $("#contenedor-cliente").hide("slow");
-                    $("#tipo").val(1);// Matriz
                 }
                 if (tipoCliente == "0") {
                     $("#contenedor-cliente").show("slow");
-                    $("#tipo").val(0);// Sucursal
                 }
               
             }
@@ -445,7 +443,6 @@
                                         Cliente
                                         <%}%>
                                     </span>
-                                    <input type="hidden" id="matriz"/>
                                 </div>
                                 <br class="clear"/>
                                 <div class="content">

--- a/web/jsp/catClientes/catClientes_form.jsp
+++ b/web/jsp/catClientes/catClientes_form.jsp
@@ -3,9 +3,6 @@
     Created on : 26-oct-2012, 12:13:49
     Author     : ISCesarMartinez poseidon24@hotmail.com
 --%>
-
-<%@page import="com.tsp.gespro.hibernate.dao.ClientesClientesDAO"%>
-<%@page import="com.tsp.gespro.hibernate.pojo.ClientesClientes"%>
 <%@page import="com.tsp.gespro.hibernate.pojo.CampoAdicionalClienteValor"%>
 <%@page import="com.tsp.gespro.hibernate.dao.CampoAdicionalClienteValorDAO"%>
 <%@page import="java.util.List"%>
@@ -36,6 +33,7 @@
 <%@page contentType="text/html" pageEncoding="UTF-8"%>
 <jsp:useBean id="user" scope="session" class="com.tsp.gespro.bo.UsuarioBO"/>
 <jsp:useBean id="helperEtiquetaCliente" class="com.tsp.gespro.hibernate.dao.EtiquetaFormularioClienteDAO"/>
+<jsp:useBean id="clienteModel" class="com.tsp.gespro.hibernate.dao.ClienteDAO"/>
 <%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
 <%@taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%
@@ -88,15 +86,9 @@
 
         ClienteBO clienteBO = new ClienteBO(user.getConn());
         Cliente clientesDto = null;
-        ClientesClientes relacionC=null;
         if (idCliente > 0) {
             clienteBO = new ClienteBO(idCliente, user.getConn());
             clientesDto = clienteBO.getCliente();
-            String where="where cliente_id="+idCliente;
-            int relacion=new ClientesClientesDAO().exist(where);
-            if(relacion!=0){
-                relacionC=new ClientesClientesDAO().getById(relacion);
-            }
             /*
             StringTokenizer tokensDias = new StringTokenizer(StringManage.getValidString(clientesDto.getDiasVisita()),",");
             String seleccion = "";
@@ -244,8 +236,7 @@
                                                     adicionalesCliente.push(adicionalCliente);
                                                 }
                                             });
-                                            console.log ("Probando :");
-                                            console.log(adicionalesCliente);
+
                                             $.ajax({
                                                 type: "POST",
                                                 url: "ajaxAdicionalesCliente.jsp",
@@ -454,6 +445,7 @@
                                         Cliente
                                         <%}%>
                                     </span>
+                                    <input type="hidden" id="matriz"/>
                                 </div>
                                 <br class="clear"/>
                                 <div class="content">
@@ -691,14 +683,12 @@
                                         <label>* ¿Eres matriz?:</label><br/>
                                         <input type="radio" name="tipoCliente" value="1"> Sí
                                         <input type="radio" name="tipoCliente" value="0"> No
-                                        <input type="hidden" id="tipo"/>
                                     </p>
                                     <br/>
                                     <div id="contenedor-cliente">
                                         <p>
-                                            <jsp:useBean id="clienteModel" class="com.tsp.gespro.hibernate.dao.ClienteDAO"/>
                                             <label>Cliente:</label><br/>
-                                            <c:set var="clientes" value="${clienteModel.lista()}"/>
+                                            <c:set var="clientes" value="${clienteModel.clientesMatrices()}"/>
                                             <select id="idC" name="idC" style="width:300px;">
                                                 <option value="0">Seleccione un cliente</option>
                                                 <c:forEach items="${clientes}" var="cliente">


### PR DESCRIPTION
## Problema
- En el combo de matrices aparecian todos los clientes, sólo debían aparecer los clientes matriz.
- Cada que un cliente modifique si es matriz o no, debe concordar con la base de datos.
## Solución
- Llenar el combo sólo con clientes matriz.
- Eliminar todos los registros de ese cliente de la tabla clientes-clientes ya sea cuando se actualice o inserte uno nuevo, la tabla intermedia sólo es de relaciones, así que no tenía sentido actualizar ese registro, el estándar es crear uno nuevo.
